### PR TITLE
Add type-specific note view pages with router-based navigation

### DIFF
--- a/frontend/pages/notes/index.js
+++ b/frontend/pages/notes/index.js
@@ -1,6 +1,6 @@
-// pages/notes.js  (or wherever this lives)
+// pages/notes/index.js
 import {useEffect, useMemo, useState} from "react";
-import Link from "next/link";
+import {useRouter} from "next/router";
 import {SearchIcon} from "lucide-react";
 
 /** helper: parse YYYY-MM-DD or ISO to safe Date (UTC to avoid off-by-one) */
@@ -30,6 +30,7 @@ const TYPE_META = {
 };
 
 export default function TherapistNotesPage() {
+    const router = useRouter();
     const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(true);
     const [query, setQuery] = useState("");
@@ -78,7 +79,7 @@ export default function TherapistNotesPage() {
                             type: typeKey,
                             patientName: patientName || "Unknown patient",
                             date: parseYmd(dateStr) || new Date(),
-                            href: `/notes/view?type=${typeKey.toLowerCase()}&id=${row.id}`,
+                            href: `/notes/${typeKey.toLowerCase()}/${row.id}`,
                         };
                     });
 
@@ -112,7 +113,11 @@ export default function TherapistNotesPage() {
     const toggleType = (t) => {
         setFilterTypes((prev) => {
             const next = new Set(prev);
-            next.has(t) ? next.delete(t) : next.add(t);
+            if (next.has(t)) {
+                next.delete(t);
+            } else {
+                next.add(t);
+            }
             return next;
         });
     };
@@ -196,12 +201,12 @@ export default function TherapistNotesPage() {
                                     </p>
                                 </div>
 
-                                <Link
-                                    href={item.href}
+                                <button
+                                    onClick={() => router.push(item.href)}
                                     className="text-brandLavender hover:underline text-sm font-medium self-start sm:self-auto"
                                 >
                                     View
-                                </Link>
+                                </button>
                             </div>
 
                             {/* hover overlay effect */}

--- a/frontend/pages/notes/intake/[id].js
+++ b/frontend/pages/notes/intake/[id].js
@@ -1,0 +1,31 @@
+import {useRouter} from "next/router";
+import {useEffect, useState} from "react";
+
+export default function IntakeFormView() {
+    const router = useRouter();
+    const {id} = router.query;
+    const [form, setForm] = useState(null);
+
+    useEffect(() => {
+        if (!id) return;
+        const token = typeof window !== "undefined" ? localStorage.getItem("pies-token") : null;
+        if (!token) return;
+        fetch(`http://localhost:8080/intakes/${id}`, {
+            headers: {Authorization: `Bearer ${token}`},
+        })
+            .then((res) => res.json())
+            .then(setForm)
+            .catch((err) => console.error(err));
+    }, [id]);
+
+    if (!form) {
+        return <p className="p-4">Loading...</p>;
+    }
+
+    return (
+        <div className="max-w-3xl mx-auto p-4 space-y-4">
+            <h1 className="text-xl font-semibold">Intake Form #{id}</h1>
+            <pre className="bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(form, null, 2)}</pre>
+        </div>
+    );
+}

--- a/frontend/pages/notes/self/[id].js
+++ b/frontend/pages/notes/self/[id].js
@@ -1,0 +1,31 @@
+import {useRouter} from "next/router";
+import {useEffect, useState} from "react";
+
+export default function SelfAssessmentView() {
+    const router = useRouter();
+    const {id} = router.query;
+    const [assessment, setAssessment] = useState(null);
+
+    useEffect(() => {
+        if (!id) return;
+        const token = typeof window !== "undefined" ? localStorage.getItem("pies-token") : null;
+        if (!token) return;
+        fetch(`http://localhost:8080/self-assessments/${id}`, {
+            headers: {Authorization: `Bearer ${token}`},
+        })
+            .then((res) => res.json())
+            .then(setAssessment)
+            .catch((err) => console.error(err));
+    }, [id]);
+
+    if (!assessment) {
+        return <p className="p-4">Loading...</p>;
+    }
+
+    return (
+        <div className="max-w-3xl mx-auto p-4 space-y-4">
+            <h1 className="text-xl font-semibold">Self Assessment #{id}</h1>
+            <pre className="bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(assessment, null, 2)}</pre>
+        </div>
+    );
+}

--- a/frontend/pages/notes/soap/[id].js
+++ b/frontend/pages/notes/soap/[id].js
@@ -1,0 +1,31 @@
+import {useRouter} from "next/router";
+import {useEffect, useState} from "react";
+
+export default function SoapNoteView() {
+    const router = useRouter();
+    const {id} = router.query;
+    const [note, setNote] = useState(null);
+
+    useEffect(() => {
+        if (!id) return;
+        const token = typeof window !== "undefined" ? localStorage.getItem("pies-token") : null;
+        if (!token) return;
+        fetch(`http://localhost:8080/soap-notes/${id}`, {
+            headers: {Authorization: `Bearer ${token}`},
+        })
+            .then((res) => res.json())
+            .then(setNote)
+            .catch((err) => console.error(err));
+    }, [id]);
+
+    if (!note) {
+        return <p className="p-4">Loading...</p>;
+    }
+
+    return (
+        <div className="max-w-3xl mx-auto p-4 space-y-4">
+            <h1 className="text-xl font-semibold">SOAP Note #{id}</h1>
+            <pre className="bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(note, null, 2)}</pre>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Redirect notes list entries to type-specific pages using router push
- Implement SOAP, self-assessment, and intake detail pages that fetch data by id

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: '_' is defined but never used, setValue is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68991d339f248322912844113e896e69